### PR TITLE
Uniform related content and latest posts

### DIFF
--- a/layouts/partials/latest-posts.html
+++ b/layouts/partials/latest-posts.html
@@ -6,12 +6,12 @@
     {{ range first 6 $othr }}
         {{ if .Params.external_url }}
             <li>
-		        <a href="{{ .Params.external_url }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "2006/01/02" }}</aside></a><br/>
+		        <a href="{{ .Params.external_url }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "January 02, 2006" }}</aside></a><br/>
 		        {{ .Description }}
             </li>
         {{ else }}
             <li>
-		        <a href="{{ .URL }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "2006/01/02" }}, {{ .ReadingTime }} min reading time</aside></a><br/>
+		        <a href="{{ .URL }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "January 02, 2006" }}, {{ .ReadingTime }} min reading time</aside></a><br/>
 		        {{ .Description }}
             </li>
         {{ end }}

--- a/layouts/partials/post/related-content.html
+++ b/layouts/partials/post/related-content.html
@@ -5,11 +5,21 @@
 {{ if $.Scratch.Get "has_related" }}
   <aside>
     <header><strong>Related Content</strong></header>
-    <hr>
-    <ul>
+    <br/>
+    <ul id="post-list" class="archive readmore">
       {{ $num_to_show := .Site.Params.related_content_limit | default 7 }}
       {{ range first $num_to_show (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink) }}
-        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> &ndash; {{ .ReadingTime }} min read
+        {{ if .Params.external_url }}
+            <li>
+		        <a href="{{ .Params.external_url }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "January 02, 2006" }}</aside></a><br/>
+		        {{ .Description }}
+            </li>
+        {{ else }}
+            <li>
+		        <a href="{{ .URL }}">{{ humanize .Section }}: {{ .LinkTitle }}<aside class="dates">{{ .Date.Format "January 02, 2006" }}, {{ .ReadingTime }} min reading time</aside></a><br/>
+		        {{ .Description }}
+            </li>
+        {{ end }}
       {{ end }}
     </ul>
   </aside>


### PR DESCRIPTION
Make them look the same when listing related and latest content.

Change date format to January 02, 2006